### PR TITLE
Fix for GET requests always unauthorized

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -70,9 +70,9 @@ GoogleTokenStrategy.prototype.authenticate = function(req, options) {
     return this.fail();
   }
 
-  if (!req.body) {
-    return this.fail();
-  }
+  // if (!req.body) {
+  //   return this.fail();
+  // }
 
   var accessToken = req.body.access_token || req.query.access_token || req.headers.access_token;
   var refreshToken = req.body.refresh_token || req.query.refresh_token || req.headers.refresh_token;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -70,12 +70,9 @@ GoogleTokenStrategy.prototype.authenticate = function(req, options) {
     return this.fail();
   }
 
-  // if (!req.body) {
-  //   return this.fail();
-  // }
+  var accessToken = req.body ? req.body.access_token || req.query.access_token || req.headers.access_token : req.headers.access_token || req.query.access_token;
+  var refreshToken = req.body ? req.body.refresh_token || req.query.refresh_token || req.headers.refresh_token : req.headers.refresh_token || req.query.refresh_token;
 
-  var accessToken = req.body.access_token || req.query.access_token || req.headers.access_token;
-  var refreshToken = req.body.refresh_token || req.query.refresh_token || req.headers.refresh_token;
 
   self._loadUserProfile(accessToken, function(err, profile) {
     if (err) { return self.fail(err); };


### PR DESCRIPTION
Mainstream browsers doesn't allow you to GET requests have body, therefor they always return unauthorised. 

This PR fixes this. 